### PR TITLE
[CARE-31] setting spring cloud bus

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,3 +41,11 @@ dependencyManagement {
 tasks.named('test') {
 	useJUnitPlatform()
 }
+
+processResources.dependsOn('copyGitSubmodule')
+tasks.register('copyGitSubmodule', Copy) {
+	from './CARING-Back-submodule'
+	include '*.yml'
+	include 'firebase-service-account.json'
+	into 'src/main/resources'
+}

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	implementation 'org.springframework.boot:spring-boot-starter-amqp'
+	implementation 'org.springframework.cloud:spring-cloud-starter-bus-amqp'
 	implementation "org.springframework.cloud:spring-cloud-starter-bootstrap"
 	implementation 'org.springframework.cloud:spring-cloud-config-server'
 	implementation 'org.springframework.cloud:spring-cloud-starter'

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ ext {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-amqp'
+	implementation "org.springframework.cloud:spring-cloud-starter-bootstrap"
 	implementation 'org.springframework.cloud:spring-cloud-config-server'
 	implementation 'org.springframework.cloud:spring-cloud-starter'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/caring/config_service/ConfigServiceApplication.java
+++ b/src/main/java/com/caring/config_service/ConfigServiceApplication.java
@@ -2,8 +2,10 @@ package com.caring.config_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.config.server.EnableConfigServer;
 
 @SpringBootApplication
+@EnableConfigServer
 public class ConfigServiceApplication {
 
 	public static void main(String[] args) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=config-service

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,22 @@
+server:
+  port: 8888
+
+spring:
+  application:
+    name: config-service
+#  cloud:
+#    config:
+#      server:
+#        git:
+#          uri: https://github.com/Han-Jeong/msa_study_yml
+  rabbitmq:
+    host: 127.0.0.1
+    port: 5672
+    username: msa_user
+    password: test123
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,11 +4,13 @@ server:
 spring:
   application:
     name: config-service
-#  cloud:
-#    config:
-#      server:
-#        git:
-#          uri: https://github.com/Han-Jeong/msa_study_yml
+  cloud:
+    config:
+      server:
+        git:
+          uri: https://github.com/green-touch/CARING-Back-submodule
+          username: ${GITHUB_USERNAME}
+          password: ${GITHUB_PASSWORD}
   rabbitmq:
     host: 127.0.0.1
     port: 5672


### PR DESCRIPTION
## #️⃣ 요약 설명
> spring cloud bus(rabbitmq)를 사용하여 config를 해당 서버에서 총괄할 수 있도록함(가져오는 yml은 private repo에서 가져옴)
## 📝 작업 내용

```java
server:
  port: 8888

spring:
  application:
    name: config-service
  cloud:
    config:
      server:
        git:
          uri: https://github.com/green-touch/CARING-Back-submodule
          username: ${GITHUB_USERNAME}
          password: ${GITHUB_PASSWORD}
  rabbitmq:
    host: 127.0.0.1
    port: 5672
    username: msa_user
    password: test123

management:
  endpoints:
    web:
      exposure:
        include: "*"
```

## 동작 확인
### 1
<img width="532" alt="issue#3_1" src="https://github.com/user-attachments/assets/f057a441-55ed-4fa5-a133-8757b77dd3f2" />

### 2
<img width="1619" alt="issue#3_2" src="https://github.com/user-attachments/assets/489d4064-fe60-4f57-b395-994b3ccfb379" />

>변경사항 작성 후 push

### 3
<img width="951" alt="issue#3_3" src="https://github.com/user-attachments/assets/f6a21d09-9457-43e6-a569-3c42a4f67a14" />

>actuator/refresh(POST) 호출하면 config 파일을 서버 재실행 없이 다시 읽을 수 있음

### 4
<img width="416" alt="issue#3_4" src="https://github.com/user-attachments/assets/f451c5b4-d9bf-47f7-ab57-5ff2df8fa70f" />


## 💬 리뷰 요구사항(선택)
없음